### PR TITLE
vendor_check() fix

### DIFF
--- a/geowifi.py
+++ b/geowifi.py
@@ -725,7 +725,11 @@ def vendor_check(bssid):
         return data
     except requests.exceptions.RequestException as e:
         # Return an error message if an exception occurs
-        return {'error': str(e)}
+        return {
+            'module': 'vendor_check',
+            'vendor': 'Unknown',
+            'error': str(e)
+        }
 
 
 def search_networks(bssid=None, ssid=None):


### PR DESCRIPTION
fix for issue #15

`vendor_check()` exception return is not handled properly in `print_results_table()`  and in `create_map()` functions

`https://api.macvendors.com/6E:5A:B0:8E:30:60` GET request returns 404 with this response
 `{"errors":{"detail":"Not Found"}}`

Before patch
```
python geowifi.py -s bssid -o map 6E:5A:B0:8E:30:60

   ██████╗ ███████╗ ██████╗   ██╗    ██╗     ███████╗ 
  ██╔════╝ ██╔════╝██╔═══██╗  ██║    ██║ ██╗ ██╔════╝ ██╗
  ██║  ███╗█████╗  ██║   ██║  ██║ █╗ ██║ ██║ █████╗   ██║
  ██║   ██║██╔══╝  ██║   ██║  ██║███╗██║ ██║ ██╔══╝   ██║
  ╚██████╔╝███████╗╚██████╔╝  ╚███╔███╔╝ ██║ ██║      ██║
   ╚═════╝ ╚══════╝ ╚═════╝    ╚══╝╚══╝  ╚═╝ ╚═╝      ╚═╝ 🌍by GOΠZO                          

Traceback (most recent call last):
  File "/home/microgod/git/geowifi/geowifi.py", line 955, in <module>
    print_results_table(search_results)
  File "/home/microgod/git/geowifi/geowifi.py", line 881, in print_results_table
    if result['module'] != 'vendor_check':
KeyError: 'module'
```

After
```
python geowifi.py -s bssid -o map 6E:5A:B0:8E:30:60

   ██████╗ ███████╗ ██████╗   ██╗    ██╗     ███████╗ 
  ██╔════╝ ██╔════╝██╔═══██╗  ██║    ██║ ██╗ ██╔════╝ ██╗
  ██║  ███╗█████╗  ██║   ██║  ██║ █╗ ██║ ██║ █████╗   ██║
  ██║   ██║██╔══╝  ██║   ██║  ██║███╗██║ ██║ ██╔══╝   ██║
  ╚██████╔╝███████╗╚██████╔╝  ╚███╔███╔╝ ██║ ██║      ██║
   ╚═════╝ ╚══════╝ ╚═════╝    ╚══╝╚══╝  ╚═╝ ╚═╝      ╚═╝ 🌍by GOΠZO                          

                         Search Results                          
┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Module   ┃       BSSID       ┃ SSID ┃ Latitude ┃  Longitude   ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ google   │        ❌         │  ❌  │    ❌    │      ❌      │
│ mylnikov │        ❌         │  ❌  │    ❌    │      ❌      │
│ combain  │        ❌         │  ❌  │    ❌    │      ❌      │
│ apple    │ 6E:5A:B0:8E:30:60 │  ❌  │ 26.46875 │ -80.10745239 │
│ wigle    │        ❌         │  ❌  │    ❌    │      ❌      │
└──────────┴───────────────────┴──────┴──────────┴──────────────┘

 [🔴] Error in google module: api key not valid. please pass a valid api key.
 [🔴] Error in mylnikov module: object was not found
 [🔴] Error in combain module: key missing or invalid
 [🔴] Error in vendor_check module: 404 client error: not found for url: https://api.macvendors.com/6e:5a:b0:8e:30:60
 [🔴] Error in wigle module: expecting value: line 1 column 1 (char 0)

 [🟢]  Vendor_check module result: : Unknown

 [🟢] Map saved at: /home/microgod/git/forks/geowifi\results\6E_5A_B0_8E_30_60.html
```

![img](https://i.imgur.com/mg2w4r1.png)